### PR TITLE
can't install pypy to ubuntu(x86_64)

### DIFF
--- a/pythonz/installer/pythoninstaller.py
+++ b/pythonz/installer/pythoninstaller.py
@@ -353,7 +353,7 @@ class PyPyInstaller(Installer):
             return 'https://bitbucket.org/pypy/pypy/downloads/pypy-%(version)s-osx64.tar.bz2' % {'version': version}
         else:
             # Linux
-            arch = {4: '', 8: 'x86_64'}[ctypes.sizeof(ctypes.c_size_t)]
+            arch = {4: '', 8: '64'}[ctypes.sizeof(ctypes.c_size_t)]
             return 'https://bitbucket.org/pypy/pypy/downloads/pypy-%(version)s-linux%(arch)s.tar.bz2' % {'arch': arch, 'version': version}
 
     def install(self):


### PR DESCRIPTION
```
$ uname -ms
Linux x86_64
$ pythonz install -t pypy 1.9
(snip)
DownloadError: Failed to fetch https://bitbucket.org/pypy/pypy/downloads/pypy-1.9-linuxx86_64.tar.bz2
```

it seems URL is wrong, correct URL is .../pypy-1.9-linux64.tar.bz2 (https://bitbucket.org/pypy/pypy/downloads) 
