### PR TITLE
Add an option to build a shared library

### DIFF
--- a/pythonz/installer/pythoninstaller.py
+++ b/pythonz/installer/pythoninstaller.py
@@ -278,15 +278,13 @@ class CPythonInstaller(Installer):
         self._apply_patches()
 
     def configure(self):
-        env = None
         if not self.options.static:
-            env = dict(os.environ)
-            env['LDFLAGS'] = '-Xlinker -rpath=\$$ORIGIN/../lib' + env.get('LDFLAGS', '')
+            os.environ['LDFLAGS'] = '-Xlinker -rpath=\$$ORIGIN/../lib ' + os.environ.get('LDFLAGS', '')
             # make sure rpath dir exists
             lib_dir = os.path.join(self.install_dir, 'lib')
             if not os.path.exists(lib_dir):
                 os.makedirs(lib_dir)
-        s = Subprocess(log=self.logfile, cwd=self.build_dir, verbose=self.options.verbose, env=env)
+        s = Subprocess(log=self.logfile, cwd=self.build_dir, verbose=self.options.verbose)
         cmd = "./configure --prefix=%s %s %s" % (self.install_dir, self.options.configure, ' '.join(self.configure_options))
         if self.options.verbose:
             logger.log(cmd)

--- a/pythonz/util.py
+++ b/pythonz/util.py
@@ -239,12 +239,11 @@ def is_sequence(val):
 # class
 #-----------------------------
 class Subprocess(object):
-    def __init__(self, log=None, cwd=None, verbose=False, debug=False, env=None):
+    def __init__(self, log=None, cwd=None, verbose=False, debug=False):
         self._log = log
         self._cwd = cwd
         self._verbose = verbose
         self._debug = debug
-        self._env = env
 
     def chdir(self, cwd):
         self._cwd = cwd
@@ -270,7 +269,7 @@ class Subprocess(object):
             logger.log(cmd)
 
         fp = ((self._log and open(self._log, 'a')) or None)
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=self._cwd, env=self._env)
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=self._cwd)
         while p.returncode is None:
             while any(select.select([p.stdout], [], [])):
                 line = to_str(p.stdout.readline())


### PR DESCRIPTION
I found that Python's shared library is not built in Linux. This patch will fix the issue. Could you please merge this patch?
