### PR TITLE
Added patch to fix svnversion error in Python 2.5

### DIFF
--- a/pythonz/installer/pythoninstaller.py
+++ b/pythonz/installer/pythoninstaller.py
@@ -202,7 +202,7 @@ class CPythonInstaller(Installer):
             self._append_patch(patch_dir, ['patch-setup.py.diff'])
         elif is_python25(version):
             patch_dir = os.path.join(PATH_PATCHES_ALL, "python25")
-            self._append_patch(patch_dir, ['patch-setup.py.diff'])
+            self._append_patch(patch_dir, ['patch-setup.py.diff', 'patch-svnversion.patch'])
         elif is_python26(version):
             self._append_patch(common_patch_dir, ['patch-setup.py.diff'])
         elif is_python27(version):

--- a/pythonz/patches/all/python25/patch-svnversion.patch
+++ b/pythonz/patches/all/python25/patch-svnversion.patch
@@ -1,0 +1,42 @@
+--- configure.in
++++ configure.in
+@@ -767,7 +767,7 @@
+ then
+ 	SVNVERSION="svnversion \$(srcdir)"
+ else
+-	SVNVERSION="echo exported"
++	SVNVERSION="echo Unversioned directory"
+ fi
+ 
+ case $MACHDEP in
+--- Makefile.pre.in
++++ Makefile.pre.in
+@@ -501,7 +501,7 @@
+ 		$(SIGNAL_OBJS) \
+ 		$(MODOBJS) \
+ 		$(srcdir)/Modules/getbuildinfo.c
+-	$(CC) -c $(PY_CFLAGS) -DSVNVERSION=\"`LC_ALL=C $(SVNVERSION)`\" -o $@ $(srcdir)/Modules/getbuildinfo.c
++	$(CC) -c $(PY_CFLAGS) -DSVNVERSION="\"`LC_ALL=C $(SVNVERSION)`\"" -o $@ $(srcdir)/Modules/getbuildinfo.c
+ 
+ Modules/getpath.o: $(srcdir)/Modules/getpath.c Makefile
+ 	$(CC) -c $(PY_CFLAGS) -DPYTHONPATH='"$(PYTHONPATH)"' \
+--- Modules/getbuildinfo.c
++++ Modules/getbuildinfo.c
+@@ -48,5 +48,5 @@
+ 	static const char svnversion[] = SVNVERSION;
+ 	if (svnversion[0] != '$')
+ 		return svnversion; /* it was interpolated, or passed on command line */
+-	return "exported";
++	return "Unversioned directory";
+ }
+--- Python/sysmodule.c
++++ Python/sysmodule.c
+@@ -1161,7 +1161,7 @@
+ 
+ 
+ 	svnversion = _Py_svnversion();
+-	if (strcmp(svnversion, "exported") != 0)
++	if (strcmp(svnversion, "Unversioned directory") != 0 && strcmp(svnversion, "exported") != 0)
+ 		svn_revision = svnversion;
+ 	else if (istag) {
+ 		len = strlen(_patchlevel_revision);


### PR DESCRIPTION
This is related to Issue 6904 in CPython, where the compilation fails when
using recent versions of subversion. This affects mainly rolling-release
Linux distributions. Notice that pythonbrew has exactly this same issue.
