### PR TITLE
Create PATH_DISTS and PATH_LOG.

### DIFF
--- a/pythonz/installer/pythoninstaller.py
+++ b/pythonz/installer/pythoninstaller.py
@@ -8,7 +8,7 @@ import multiprocessing
 import re
 import subprocess
 
-from pythonz.util import symlink, Package, is_url, Link,\
+from pythonz.util import symlink, makedirs, Package, is_url, Link,\
     unlink, is_html, Subprocess, rm_r, is_python26, is_python27,\
     extract_downloadfile, is_archive_file, path_to_fileurl, is_file,\
     fileurl_to_path, is_python30, is_python31, is_python32,\
@@ -39,6 +39,10 @@ class Installer(object):
     supported_versions = []
 
     def __init__(self, version, options):
+        # create directories
+        makedirs(PATH_DISTS)
+        makedirs(PATH_LOG)
+
         if options.file is not None:
             if not (is_archive_file(options.file) and os.path.isfile(options.file)):
                 logger.error('invalid file specified: %s' % options.file)


### PR DESCRIPTION
To alleviate these errors:

```
salt:/home/vagrant # /usr/local/pythonz/bin/pythonz install 2.7.3
Downloading Python-2.7.3.tgz as /root/.pythonz/dists/Python-2.7.3.tgz

ERROR: Failed to download.
Failed to fetch /root/.pythonz/dists/Python-2.7.3.tgz from http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz
salt:/home/vagrant #
```

And:

```
salt:/home/vagrant # /usr/local/pythonz/bin/pythonz install 2.7.3
Downloading Python-2.7.3.tgz as /root/.pythonz/dists/Python-2.7.3.tgz
########################################################################## 100%
Extracting Python-2.7.3.tgz into /root/.pythonz/build/CPython-2.7.3

This could take a while. You can run the following command on another shell to track the status:
  tail -f /root/.pythonz/log/build.log

Installing CPython-2.7.3 into /root/.pythonz/pythons/CPython-2.7.3
Traceback (most recent call last):
  File /usr/local/pythonz/scripts/pythonz/installer/pythoninstaller.py, line 183, in install
    self.configure()
  File /usr/local/pythonz/scripts/pythonz/installer/pythoninstaller.py, line 303, in configure
    s.check_call(cmd)
  File /usr/local/pythonz/scripts/pythonz/util.py, line 292, in check_call
    returncode = self.call(cmd)
  File /usr/local/pythonz/scripts/pythonz/util.py, line 274, in call
    fp = ((self._log and open(self._log, 'a')) or None)
IOError: [Errno 2] No such file or directory: '/root/.pythonz/log/build.log'
ERROR: Failed to install CPython-2.7.3. Check /root/.pythonz/log/build.log to see why.
salt:/home/vagrant
```
