### PR TITLE
fix bash version detect so that it can support zsh

### DIFF
--- a/pythonz/etc/bashrc
+++ b/pythonz/etc/bashrc
@@ -84,7 +84,7 @@ __pythonz_bash_completion()
 __pythonz_set_path
 
 # nebale completion on bash >= 4
-if [ ${BASH_VERSION:0:1} -ge 4 ]; then
+if [ ${BASH_VERSION} ] && [ ${BASH_VERSION:0:1} -ge 4 ]; then
     __pythonz_bash_completion
     declare -A _pythonz_context
 fi


### PR DESCRIPTION
zsh didn't support `-ge`. This patch will allow zsh to source the rc file.
