### PR TITLE
Disable SSLv2 in Python 3.0.*

### DIFF
--- a/pythonz/installer/pythoninstaller.py
+++ b/pythonz/installer/pythoninstaller.py
@@ -219,7 +219,8 @@ class CPythonInstaller(Installer):
                 self._append_patch(common_patch_dir, ['patch-setup.py.diff'])
         elif is_python30(version):
             patch_dir = os.path.join(PATH_PATCHES_ALL, "python30")
-            self._append_patch(patch_dir, ['patch-setup.py.diff'])
+            self._append_patch(patch_dir, ['patch-setup.py.diff',
+                                           'patch-nosslv2.diff'])
         elif is_python31(version):
             if version < '3.1.4':
                 self._append_patch(common_patch_dir, ['patch-setup.py.diff'])

--- a/pythonz/patches/all/python30/patch-nosslv2.diff
+++ b/pythonz/patches/all/python30/patch-nosslv2.diff
@@ -1,0 +1,132 @@
+--- Doc/library/ssl.rst	2009-01-04 09:04:26.000000000 +0900
++++ Doc/library/ssl.rst	2013-08-10 01:33:57.400047147 +0900
+@@ -217,10 +217,6 @@
+    validation file also be passed as a value of the ``ca_certs``
+    parameter.
+ 
+-.. data:: PROTOCOL_SSLv2
+-
+-   Selects SSL version 2 as the channel encryption protocol.
+-
+ .. data:: PROTOCOL_SSLv23
+ 
+    Selects SSL version 2 or 3 as the channel encryption protocol.
+--- Lib/ssl.py	2009-01-04 08:47:58.000000000 +0900
++++ Lib/ssl.py	2013-08-10 01:32:30.448047220 +0900
+@@ -48,7 +48,6 @@
+ 
+ The following constants identify various SSL protocol variants:
+ 
+-PROTOCOL_SSLv2
+ PROTOCOL_SSLv3
+ PROTOCOL_SSLv23
+ PROTOCOL_TLSv1
+@@ -60,8 +59,7 @@
+ 
+ from _ssl import SSLError
+ from _ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
+-from _ssl import (PROTOCOL_SSLv2, PROTOCOL_SSLv3, PROTOCOL_SSLv23,
+-                  PROTOCOL_TLSv1)
++from _ssl import PROTOCOL_SSLv3, PROTOCOL_SSLv23, PROTOCOL_TLSv1
+ from _ssl import RAND_status, RAND_egd, RAND_add
+ from _ssl import (
+     SSL_ERROR_ZERO_RETURN,
+@@ -438,8 +436,6 @@
+         return "TLSv1"
+     elif protocol_code == PROTOCOL_SSLv23:
+         return "SSLv23"
+-    elif protocol_code == PROTOCOL_SSLv2:
+-        return "SSLv2"
+     elif protocol_code == PROTOCOL_SSLv3:
+         return "SSLv3"
+     else:
+--- Lib/test/test_ssl.py	2008-09-09 01:45:19.000000000 +0900
++++ Lib/test/test_ssl.py	2013-08-10 01:47:16.888046481 +0900
+@@ -58,7 +58,6 @@
+             s.close()
+ 
+     def testCrucialConstants(self):
+-        ssl.PROTOCOL_SSLv2
+         ssl.PROTOCOL_SSLv23
+         ssl.PROTOCOL_SSLv3
+         ssl.PROTOCOL_TLSv1
+@@ -825,27 +824,9 @@
+             connector()
+             t.join()
+ 
+-        def testProtocolSSL2(self):
+-            if support.verbose:
+-                sys.stdout.write("\n")
+-            tryProtocolCombo(ssl.PROTOCOL_SSLv2, ssl.PROTOCOL_SSLv2, True)
+-            tryProtocolCombo(ssl.PROTOCOL_SSLv2, ssl.PROTOCOL_SSLv2, True, ssl.CERT_OPTIONAL)
+-            tryProtocolCombo(ssl.PROTOCOL_SSLv2, ssl.PROTOCOL_SSLv2, True, ssl.CERT_REQUIRED)
+-            tryProtocolCombo(ssl.PROTOCOL_SSLv2, ssl.PROTOCOL_SSLv23, True)
+-            tryProtocolCombo(ssl.PROTOCOL_SSLv2, ssl.PROTOCOL_SSLv3, False)
+-            tryProtocolCombo(ssl.PROTOCOL_SSLv2, ssl.PROTOCOL_TLSv1, False)
+-
+         def testProtocolSSL23(self):
+             if support.verbose:
+                 sys.stdout.write("\n")
+-            try:
+-                tryProtocolCombo(ssl.PROTOCOL_SSLv23, ssl.PROTOCOL_SSLv2, True)
+-            except support.TestFailed as x:
+-                # this fails on some older versions of OpenSSL (0.9.7l, for instance)
+-                if support.verbose:
+-                    sys.stdout.write(
+-                        " SSL2 client to SSL23 server test unexpectedly failed:\n %s\n"
+-                        % str(x))
+             tryProtocolCombo(ssl.PROTOCOL_SSLv23, ssl.PROTOCOL_SSLv3, True)
+             tryProtocolCombo(ssl.PROTOCOL_SSLv23, ssl.PROTOCOL_SSLv23, True)
+             tryProtocolCombo(ssl.PROTOCOL_SSLv23, ssl.PROTOCOL_TLSv1, True)
+@@ -864,7 +845,6 @@
+             tryProtocolCombo(ssl.PROTOCOL_SSLv3, ssl.PROTOCOL_SSLv3, True)
+             tryProtocolCombo(ssl.PROTOCOL_SSLv3, ssl.PROTOCOL_SSLv3, True, ssl.CERT_OPTIONAL)
+             tryProtocolCombo(ssl.PROTOCOL_SSLv3, ssl.PROTOCOL_SSLv3, True, ssl.CERT_REQUIRED)
+-            tryProtocolCombo(ssl.PROTOCOL_SSLv3, ssl.PROTOCOL_SSLv2, False)
+             tryProtocolCombo(ssl.PROTOCOL_SSLv3, ssl.PROTOCOL_SSLv23, False)
+             tryProtocolCombo(ssl.PROTOCOL_SSLv3, ssl.PROTOCOL_TLSv1, False)
+ 
+@@ -874,7 +854,6 @@
+             tryProtocolCombo(ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_TLSv1, True)
+             tryProtocolCombo(ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_TLSv1, True, ssl.CERT_OPTIONAL)
+             tryProtocolCombo(ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_TLSv1, True, ssl.CERT_REQUIRED)
+-            tryProtocolCombo(ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_SSLv2, False)
+             tryProtocolCombo(ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_SSLv3, False)
+             tryProtocolCombo(ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_SSLv23, False)
+ 
+--- Modules/_ssl.c	2009-02-03 05:41:29.000000000 +0900
++++ Modules/_ssl.c	2013-08-10 01:44:07.820046638 +0900
+@@ -62,8 +62,10 @@
+ };
+ 
+ enum py_ssl_version {
++#ifndef OPENSSL_NO_SSL2
+ 	PY_SSL_VERSION_SSL2,
+-	PY_SSL_VERSION_SSL3,
++#endif
++	PY_SSL_VERSION_SSL3=1,
+ 	PY_SSL_VERSION_SSL23,
+ 	PY_SSL_VERSION_TLS1,
+ };
+@@ -299,8 +301,10 @@
+ 		self->ctx = SSL_CTX_new(TLSv1_method()); /* Set up context */
+ 	else if (proto_version == PY_SSL_VERSION_SSL3)
+ 		self->ctx = SSL_CTX_new(SSLv3_method()); /* Set up context */
++#ifndef OPENSSL_NO_SSL2
+ 	else if (proto_version == PY_SSL_VERSION_SSL2)
+ 		self->ctx = SSL_CTX_new(SSLv2_method()); /* Set up context */
++#endif
+ 	else if (proto_version == PY_SSL_VERSION_SSL23)
+ 		self->ctx = SSL_CTX_new(SSLv23_method()); /* Set up context */
+ 	PySSL_END_ALLOW_THREADS
+@@ -1691,8 +1695,10 @@
+ 				PY_SSL_CERT_REQUIRED);
+ 
+ 	/* protocol versions */
++#ifndef OPENSSL_NO_SSL2
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv2",
+ 				PY_SSL_VERSION_SSL2);
++#endif
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv3",
+ 				PY_SSL_VERSION_SSL3);
+ 	PyModule_AddIntConstant(m, "PROTOCOL_SSLv23",


### PR DESCRIPTION
Disable SSLv2 in Python 3.0.\* as like Python 2.6.*
