### PR TITLE
Added support for Jython 2.7-b1

### DIFF
--- a/pythonz/installer/pythoninstaller.py
+++ b/pythonz/installer/pythoninstaller.py
@@ -426,7 +426,7 @@ class PyPyInstaller(Installer):
 
 
 class JythonInstaller(Installer):
-    supported_versions = ['2.5.0', '2.5.1', '2.5.2', '2.5.3']
+    supported_versions = ['2.5.0', '2.5.1', '2.5.2', '2.5.3', '2.7-b1']
 
     @classmethod
     def get_version_url(cls, version):


### PR DESCRIPTION
While Jython 2.7 is in its beta stage yet, it would be great if pythonz support it for easier/consistent setup to test/experiment with the environment. It may be removed/replaced with Jython 2.7 final releases.
