### PR TITLE
Support invocation with "python -m pythonz"

### DIFF
--- a/pythonz/__main__.py
+++ b/pythonz/__main__.py
@@ -1,0 +1,4 @@
+"""For development purposes, support invocation of pythonz with python -m."""
+
+import pythonz
+pythonz.main()


### PR DESCRIPTION
If there are any developer's notes for `pythonz` then I apologize for missing them, but — after checking out pythonz from source code — it was not clear to me how to invoke the command-line tool right from the repository. If there is in fact an official way that I should be using, then feel free to simply let me know! But otherwise I would like to contribute this simple adjustment that lets a developer who has checked the `pythonz` repository out of version control simply `cd` into the top-level project directory and then run `pythonz` with:

```
python -m pythonz
```

This makes it easy for a developer to iterate on the code sitting right in a GitHub checkout, without having to copy it anywhere else to get it to run.
