### PR TITLE
Make installation more Puppet friendly

### DIFF
--- a/pythonz-install
+++ b/pythonz-install
@@ -43,7 +43,7 @@ parse_arguments()
 parse_arguments $@
 
 if [[ ! -x $CURL ]] && [[ ! -x $FETCH ]] ; then
-    echo "pythonz required curl or fetch. Neigher of them were not found in your path."
+    echo "pythonz required curl or fetch. Neither of them were not found in your path."
     exit 1
 fi
 

--- a/pythonz/define.py
+++ b/pythonz/define.py
@@ -7,7 +7,7 @@ INSTALLER_ROOT = os.path.dirname(os.path.abspath(__file__))
 # Root
 # pythonz root path
 SYSTEMWIDE_PATH = '/usr/local/pythonz'
-ROOT = os.environ.get('PYTHONZ_ROOT') or os.path.join(os.environ['HOME'], '.pythonz') if not os.path.abspath(os.path.dirname(__file__)).startswith(SYSTEMWIDE_PATH) else SYSTEMWIDE_PATH
+ROOT = os.environ.get('PYTHONZ_ROOT') or os.path.join(os.environ.get('HOME'), '.pythonz') if not os.path.abspath(os.path.dirname(__file__)).startswith(SYSTEMWIDE_PATH) else SYSTEMWIDE_PATH
 
 # directories
 PATH_PYTHONS = os.path.join(ROOT, 'pythons')
@@ -30,7 +30,7 @@ PATH_BIN_PYTHONZ = os.path.join(PATH_BIN, 'pythonz')
 
 # Home
 # pythonz home path
-PATH_HOME = os.environ.get('PYTHONZ_HOME') or os.path.join(os.environ['HOME'], '.pythonz')
+PATH_HOME = os.environ.get('PYTHONZ_HOME') or os.path.join(os.environ.get('HOME'), '.pythonz')
 
 # directories
 PATH_HOME_ETC = os.path.join(PATH_HOME, 'etc')

--- a/pythonz/define.py
+++ b/pythonz/define.py
@@ -1,6 +1,8 @@
 
 import os
 
+from pythonz.log import logger
+
 # pythonz installer root path
 INSTALLER_ROOT = os.path.dirname(os.path.abspath(__file__))
 
@@ -19,7 +21,7 @@ elif ( HOME
 elif os.path.isdir(SYSTEMWIDE_PATH):
     ROOT = SYSTEMWIDE_PATH
 else:
-    print "No installation of pythonz found."
+    logger.error('No installation of pythonz found.')
     sys.exit(1)
 
 # directories
@@ -52,7 +54,7 @@ elif HOME:
 elif os.path.isdir(SYSTEMWIDE_PATH):
     PATH_HOME = SYSTEMWIDE_PATH
 else:
-    print "No home directory for pythonz found."
+    logger.error('No home directory for pythonz found.')
     sys.exit(1)
 
 # directories

--- a/pythonz/define.py
+++ b/pythonz/define.py
@@ -4,10 +4,23 @@ import os
 # pythonz installer root path
 INSTALLER_ROOT = os.path.dirname(os.path.abspath(__file__))
 
+HOME = os.environ.get('HOME')
+SYSTEMWIDE_PATH = '/usr/local/pythonz'
+
 # Root
 # pythonz root path
-SYSTEMWIDE_PATH = '/usr/local/pythonz'
-ROOT = os.environ.get('PYTHONZ_ROOT') or os.path.join(os.environ.get('HOME'), '.pythonz') if not os.path.abspath(os.path.dirname(__file__)).startswith(SYSTEMWIDE_PATH) else SYSTEMWIDE_PATH
+PYTHONZ_ROOT = os.environ.get('PYTHONZ_ROOT')
+if   ( PYTHONZ_ROOT
+       and os.path.isdir(PYTHONZ_ROOT) ):
+    ROOT = PYTHONZ_ROOT
+elif ( HOME
+       and os.path.isdir(os.path.join(HOME, '.pythonz')) ):
+    ROOT = os.path.join(HOME, '.pythonz')
+elif os.path.isdir(SYSTEMWIDE_PATH):
+    ROOT = SYSTEMWIDE_PATH
+else:
+    print "No installation of pythonz found."
+    sys.exit(1)
 
 # directories
 PATH_PYTHONS = os.path.join(ROOT, 'pythons')
@@ -30,7 +43,17 @@ PATH_BIN_PYTHONZ = os.path.join(PATH_BIN, 'pythonz')
 
 # Home
 # pythonz home path
-PATH_HOME = os.environ.get('PYTHONZ_HOME') or os.path.join(os.environ.get('HOME'), '.pythonz')
+PYTHONZ_HOME = os.environ.get('PYTHONZ_HOME')
+if   ( PYTHONZ_HOME
+       and os.path.isdir(PYTHONZ_HOME) ):
+    PATH_HOME = PYTHONZ_HOME
+elif HOME:
+    PATH_HOME = os.path.join(HOME, '.pythonz')
+elif os.path.isdir(SYSTEMWIDE_PATH):
+    PATH_HOME = SYSTEMWIDE_PATH
+else:
+    print "No home directory for pythonz found."
+    sys.exit(1)
 
 # directories
 PATH_HOME_ETC = os.path.join(PATH_HOME, 'etc')

--- a/pythonz/etc/bashrc
+++ b/pythonz/etc/bashrc
@@ -1,7 +1,7 @@
 # settings
 if [[ -d "$PYTHONZ_ROOT" ]] ; then
     PATH_ROOT="$PYTHONZ_ROOT"
-elif [[ -d "$HOME/.pythonz" ]]
+elif [[ -d "$HOME/.pythonz" ]]; then
     PATH_ROOT="$HOME/.pythonz"
 elif [[ -d "/usr/local/pythonz" ]] ; then
     PATH_ROOT="/usr/local/pythonz"
@@ -13,7 +13,7 @@ PATH_ETC="$PATH_ROOT/etc"
 
 if [[ -d "$PYTHONZ_HOME" ]] ; then
     PATH_HOME="$PYTHONZ_HOME"
-elif [[ -d "$HOME" ]]
+elif [[ -d "$HOME" ]]; then
     PATH_HOME="$HOME/.pythonz"
 elif [[ -d "/usr/local/pythonz" ]] ; then
     PATH_HOME="/usr/local/pythonz"

--- a/pythonz/etc/bashrc
+++ b/pythonz/etc/bashrc
@@ -1,13 +1,25 @@
 # settings
-PATH_ROOT="$PYTHONZ_ROOT"
-if [ -z "${PATH_ROOT}" ] ; then
+if [[ -d "$PYTHONZ_ROOT" ]] ; then
+    PATH_ROOT="$PYTHONZ_ROOT"
+elif [[ -d "$HOME/.pythonz" ]]
     PATH_ROOT="$HOME/.pythonz"
+elif [[ -d "/usr/local/pythonz" ]] ; then
+    PATH_ROOT="/usr/local/pythonz"
+else
+    echo "No installation of pythonz found."
+    exit 1
 fi
 PATH_ETC="$PATH_ROOT/etc"
 
-PATH_HOME="$PYTHONZ_HOME"
-if [ -z "${PATH_HOME}" ] ; then
+if [[ -d "$PYTHONZ_HOME" ]] ; then
+    PATH_HOME="$PYTHONZ_HOME"
+elif [[ -d "$HOME" ]]
     PATH_HOME="$HOME/.pythonz"
+elif [[ -d "/usr/local/pythonz" ]] ; then
+    PATH_HOME="/usr/local/pythonz"
+else
+    echo "No home directory for pythonz found."
+    exit 1
 fi
 PATH_HOME_ETC="$PATH_HOME/etc"
 


### PR DESCRIPTION
I ran into some problems running the pythonz installer with Puppet. I was trying to provision an Ubuntu 15.04 box with Vagrant/Virtualbox. In that scenario the root user has no `HOME` directory, so several things didn't work right. This pull request fixes that problem by adding more checks around the use of the `HOME` env var, in `bashrc` and `define.py`.