### PR TITLE
Add missing `import sys` in locate command

### DIFF
--- a/pythonz/commands/locate.py
+++ b/pythonz/commands/locate.py
@@ -1,5 +1,6 @@
 
 import os
+import sys
 
 from pythonz.commands import Command
 from pythonz.define import PATH_PYTHONS


### PR DESCRIPTION
Hi,

Thanks for a very cool project. I noticed a minor error when running the `pythonz locate` command with no arguments: `sys.exit` is used to exit from the script, however the `sys` module is never imported.


Cheers,
Kevin