### PR TITLE
Make it so that installation of the patches is not needed anymore

### DIFF
--- a/pythonz/define.py
+++ b/pythonz/define.py
@@ -21,7 +21,8 @@ PATH_SCRIPTS = os.path.join(ROOT, 'scripts')
 PATH_SCRIPTS_PYTHONZ = os.path.join(PATH_SCRIPTS, 'pythonz')
 PATH_SCRIPTS_PYTHONZ_COMMANDS = os.path.join(PATH_SCRIPTS_PYTHONZ, 'commands')
 PATH_SCRIPTS_PYTHONZ_INSTALLER = os.path.join(PATH_SCRIPTS_PYTHONZ, 'installer')
-PATH_PATCHES = os.path.join(ROOT, 'patches')
+
+PATH_PATCHES = os.path.join(INSTALLER_ROOT, 'patches')
 PATH_PATCHES_ALL = os.path.join(PATH_PATCHES, 'all')
 PATH_PATCHES_OSX = os.path.join(PATH_PATCHES, 'osx')
 
@@ -37,4 +38,3 @@ PATH_HOME_ETC = os.path.join(PATH_HOME, 'etc')
 
 # pythonz download
 PYTHONZ_UPDATE_URL = 'https://github.com/saghul/pythonz/archive/master.tar.gz'
-

--- a/pythonz/installer/pythonzinstaller.py
+++ b/pythonz/installer/pythonzinstaller.py
@@ -9,8 +9,7 @@ import time
 from pythonz.util import makedirs, rm_r
 from pythonz.define import PATH_BUILD, PATH_BIN, PATH_DISTS, PATH_PYTHONS,\
     PATH_ETC, PATH_SCRIPTS, PATH_SCRIPTS_PYTHONZ,\
-    PATH_SCRIPTS_PYTHONZ_COMMANDS, PATH_BIN_PYTHONZ,\
-    PATH_LOG, PATH_PATCHES,\
+    PATH_SCRIPTS_PYTHONZ_COMMANDS, PATH_BIN_PYTHONZ, PATH_LOG,\
     PATH_SCRIPTS_PYTHONZ_INSTALLER, PATH_HOME_ETC, ROOT,\
     PATH_BASH_COMPLETION
 
@@ -45,10 +44,6 @@ class PythonzInstaller(object):
             shutil.copy(path, PATH_SCRIPTS_PYTHONZ_COMMANDS)
         for path in glob.glob(os.path.join(installer_root,"installer","*.py")):
             shutil.copy(path, PATH_SCRIPTS_PYTHONZ_INSTALLER)
-
-        # create patches direcotry
-        rm_r(PATH_PATCHES)
-        shutil.copytree(os.path.join(installer_root,"patches"), PATH_PATCHES)
 
         # create a main file
         with open("%s/pythonz_main.py" % PATH_SCRIPTS, "w") as f:
@@ -110,4 +105,3 @@ fi
 
             with open('/etc/profile', 'w') as f:
                 f.write(''.join(output))
-

--- a/pythonz/installer/pythonzinstaller.py
+++ b/pythonz/installer/pythonzinstaller.py
@@ -9,7 +9,8 @@ import time
 from pythonz.util import makedirs, rm_r
 from pythonz.define import PATH_BUILD, PATH_BIN, PATH_DISTS, PATH_PYTHONS,\
     PATH_ETC, PATH_SCRIPTS, PATH_SCRIPTS_PYTHONZ,\
-    PATH_SCRIPTS_PYTHONZ_COMMANDS, PATH_BIN_PYTHONZ, PATH_LOG,\
+    PATH_SCRIPTS_PYTHONZ_COMMANDS, PATH_BIN_PYTHONZ,\
+    PATH_LOG, PATH_PATCHES,\
     PATH_SCRIPTS_PYTHONZ_INSTALLER, PATH_HOME_ETC, ROOT,\
     PATH_BASH_COMPLETION
 
@@ -44,6 +45,11 @@ class PythonzInstaller(object):
             shutil.copy(path, PATH_SCRIPTS_PYTHONZ_COMMANDS)
         for path in glob.glob(os.path.join(installer_root,"installer","*.py")):
             shutil.copy(path, PATH_SCRIPTS_PYTHONZ_INSTALLER)
+
+        # create patches direcotry
+        DEST_PATCHES = os.path.join(PATH_SCRIPTS_PYTHONZ, 'patches')
+        rm_r(DEST_PATCHES)
+        shutil.copytree(PATH_PATCHES, DEST_PATCHES)
 
         # create a main file
         with open("%s/pythonz_main.py" % PATH_SCRIPTS, "w") as f:


### PR DESCRIPTION
This fixes #73 

The change needed for it was actually only a oneliner.
This way, pythonz-install would be needed only for shell completions and other scripts (stuff not needed to drive Pythonz from another program)