### PR TITLE
Add oneshot install

### DIFF
--- a/pythonz/commands/install.py
+++ b/pythonz/commands/install.py
@@ -88,8 +88,8 @@ class InstallCommand(Command):
             help="Reinstall Python version, if already installed."
         )
         self.parser.add_option(
-            "--oneshot",
-            dest="oneshot_path",
+            "--external",
+            dest="external_path",
             default="",
             help="Install Python version in specified directory."
         )

--- a/pythonz/commands/install.py
+++ b/pythonz/commands/install.py
@@ -87,6 +87,12 @@ class InstallCommand(Command):
             default=False,
             help="Reinstall Python version, if already installed."
         )
+        self.parser.add_option(
+            "--oneshot",
+            dest="oneshot_path",
+            default="",
+            help="Install Python version in specified directory."
+        )
 
     def run_command(self, options, args):
         if not args:

--- a/pythonz/installer/pythoninstaller.py
+++ b/pythonz/installer/pythoninstaller.py
@@ -63,11 +63,11 @@ class Installer(object):
                 logger.warning("Unsupported Python version: `%s`, trying with the following URL anyway: %s" % (version, self.get_version_url(version)))
             self.download_url = self.get_version_url(version)
         self.pkg = Package(version, options.type)
-        if options.oneshot_path:
-            if not os.path.isabs(options.oneshot_path):
+        if options.external_path:
+            if not os.path.isabs(options.external_path):
                 logger.error('Install path must be absolute.')
                 raise RuntimeError
-            self.install_dir = os.path.join(options.oneshot_path,
+            self.install_dir = os.path.join(options.external_path,
                                             self.pkg.name)
         else:
             self.install_dir = os.path.join(PATH_PYTHONS, self.pkg.name)

--- a/pythonz/installer/pythoninstaller.py
+++ b/pythonz/installer/pythoninstaller.py
@@ -65,8 +65,9 @@ class Installer(object):
         self.pkg = Package(version, options.type)
         if options.external_path:
             if not os.path.isabs(options.external_path):
-                logger.error('Install path must be absolute.')
-                raise RuntimeError
+                options.external_path = os.path.join(
+                    os.path.abspath(os.path.curdir),
+                    options.external_path)
             self.install_dir = os.path.join(options.external_path,
                                             self.pkg.name)
         else:

--- a/pythonz/installer/pythoninstaller.py
+++ b/pythonz/installer/pythoninstaller.py
@@ -63,7 +63,14 @@ class Installer(object):
                 logger.warning("Unsupported Python version: `%s`, trying with the following URL anyway: %s" % (version, self.get_version_url(version)))
             self.download_url = self.get_version_url(version)
         self.pkg = Package(version, options.type)
-        self.install_dir = os.path.join(PATH_PYTHONS, self.pkg.name)
+        if options.oneshot_path:
+            if not os.path.isabs(options.oneshot_path):
+                logger.error('Install path must be absolute.')
+                raise RuntimeError
+            self.install_dir = os.path.join(options.oneshot_path,
+                                            self.pkg.name)
+        else:
+            self.install_dir = os.path.join(PATH_PYTHONS, self.pkg.name)
         self.build_dir = os.path.join(PATH_BUILD, self.pkg.name)
         filename = Link(self.download_url).filename
         self.download_file = os.path.join(PATH_DISTS, filename)


### PR DESCRIPTION
Hi,

Very neat tool, thanks for taking time and creating it.
I was missing way of installing Python versions in specific directory, under path provided by me. This installed Python's would not be visible to pythonz but this is fine for one shot installations, e.g. when creating virtualenvs, preparing transferable interpreters. 
It is much easier to let pythonz do the heavy lifting than doing it yourself, grabbing source, compiling etc.
I find this feature useful, what do you think?