### PR TITLE
Add list -a filtering by groups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,7 +139,7 @@ List all the available jython versions
 
 ::
 
-   pythonz list -a jython
+   pythonz list -a -t jython
 
 Uninstall the specified python
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,13 @@ List all the available python versions for installing
 
   pythonz list -a
 
+List all the available jython versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+   pythonz list -a jython
+
 Uninstall the specified python
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -201,4 +208,3 @@ by Jesús Cea.
 Building Python with DTrace support::
 
   pythonz install --configure="--with-dtrace" 2.7.6
-

--- a/pythonz/commands/list.py
+++ b/pythonz/commands/list.py
@@ -7,9 +7,12 @@ from pythonz.installer.pythoninstaller import CPythonInstaller, StacklessInstall
 from pythonz.log import logger
 
 
+PY_TYPES = ['cpython', 'stackless', 'pypy', 'pypy3', 'jython']
+
+
 class ListCommand(Command):
     name = "list"
-    usage = "%prog [options] [filter]"
+    usage = "%prog [options]"
     summary = "List the installed python versions"
 
     def __init__(self):
@@ -19,8 +22,7 @@ class ListCommand(Command):
             dest='all_versions',
             action='store_true',
             default=False,
-            help=('Show the all available python versions. Optionally, show '
-                  'chosen implementations. e.g.: pythonz list -a pypy3')
+            help='Show the all available python versions.'
         )
         self.parser.add_option(
             '-p', '--path',
@@ -29,10 +31,18 @@ class ListCommand(Command):
             default=False,
             help='Show the path for all Python installations.'
         )
+        self.parser.add_option(
+            '-t', '--type',
+            dest='py_type',
+            choices=PY_TYPES,
+            default=[],
+            help=('Use with -a to list only certain Python types. '
+                  'Available choices: {0}'.format(PY_TYPES))
+        )
 
     def run_command(self, options, args):
         if options.all_versions:
-            self.all(args)
+            self.all(py_type=options.py_type)
         else:
             self.installed(path=options.path)
 
@@ -44,14 +54,14 @@ class ListCommand(Command):
             else:
                 logger.log('  %s' % d)
 
-    def all(self, implementations):
+    def all(self, py_type):
         logger.log('# Available Python versions')
-        groups = zip(['cpython', 'stackless', 'pypy', 'pypy3', 'jython'],
+        groups = zip(PY_TYPES,
                      [CPythonInstaller, StacklessInstaller, PyPyInstaller,
                       PyPy3Installer, JythonInstaller])
 
-        if implementations:
-            groups = filter(lambda (impl, _): impl in implementations, groups)
+        if py_type:
+            groups = filter(lambda (impl, _): impl in py_type, groups)
 
         for type_, installer in groups:
             logger.log('  # %s:' % type_)

--- a/pythonz/commands/list.py
+++ b/pythonz/commands/list.py
@@ -9,7 +9,7 @@ from pythonz.log import logger
 
 class ListCommand(Command):
     name = "list"
-    usage = "%prog [options]"
+    usage = "%prog [options] [filter]"
     summary = "List the installed python versions"
 
     def __init__(self):
@@ -19,7 +19,8 @@ class ListCommand(Command):
             dest='all_versions',
             action='store_true',
             default=False,
-            help='Show the all available python versions.'
+            help=('Show the all available python versions. Optionally, show '
+                  'chosen implementations. e.g.: pythonz list -a pypy3')
         )
         self.parser.add_option(
             '-p', '--path',
@@ -31,7 +32,7 @@ class ListCommand(Command):
 
     def run_command(self, options, args):
         if options.all_versions:
-            self.all()
+            self.all(args)
         else:
             self.installed(path=options.path)
 
@@ -43,12 +44,18 @@ class ListCommand(Command):
             else:
                 logger.log('  %s' % d)
 
-    def all(self):
+    def all(self, implementations):
         logger.log('# Available Python versions')
-        for type, installer in zip(['cpython', 'stackless', 'pypy', 'pypy3', 'jython'], [CPythonInstaller, StacklessInstaller, PyPyInstaller, PyPy3Installer, JythonInstaller]):
-            logger.log('  # %s:' % type)
+        groups = zip(['cpython', 'stackless', 'pypy', 'pypy3', 'jython'],
+                     [CPythonInstaller, StacklessInstaller, PyPyInstaller,
+                      PyPy3Installer, JythonInstaller])
+
+        if implementations:
+            groups = filter(lambda (impl, _): impl in implementations, groups)
+
+        for type_, installer in groups:
+            logger.log('  # %s:' % type_)
             for version in installer.supported_versions:
                 logger.log('     %s' % version)
 
 ListCommand()
-


### PR DESCRIPTION
Hi,

I decided to add filtering to `-a list` when the whole list didn't fit on my screen.
With this PR you may call

```
pythonz list -a jython
```
and get only list of jython versions.
```
± % python __main__.py list -a jython
# Available Python versions
  # jython:
     2.7.0
     2.5.2
     2.5.3
     2.5.0
     2.5.1
```
I am not sure about handling arguments in `run_command` method.
What do you think?
