### PR TITLE
reporthook size could be None

### DIFF
--- a/pythonz/downloader.py
+++ b/pythonz/downloader.py
@@ -66,7 +66,7 @@ class ProgressBar(object):
         return result
 
     def reporthook(self, blocknum, bs, size):
-        if size == -1:  # disable progress bar if size not known
+        if size in (-1, None):  # disable progress bar if size not known
             return
         current = (blocknum * bs * 100) / size
         if current > 100:


### PR DESCRIPTION
While looking at https://github.com/saghul/pythonz/pull/105 I realized that it didn't cover all cases:

in resumable_urlretrieve, [`remote_size` is  `Optional[int]`](https://github.com/berdario/resumable-urlretrieve/blob/faa631f/resumable/__init__.py#L75) and can thus be `None`.

This is arguably better than an "in band" value (`-1`) used as error, because it would've made it fail fast instead of GIGOing... but the truth is that I didn't look deep in the implementation of `urllib.urlretrieve` to spot the difference, I think

Instead of `in (-1, None)` we could also do `>= 0`
