### PR TITLE
Fix list command for Python3 and tweak its logic

### DIFF
--- a/pythonz/commands/list.py
+++ b/pythonz/commands/list.py
@@ -63,7 +63,7 @@ class ListCommand(Command):
 
     def all(self, py_type):
         logger.log('# Available Python versions')
-        py_types = [ty for ty in PY_TYPES if py_type in ty] if py_type else PY_TYPES
+        py_types = [py_type] if py_type else PY_TYPES
 
         for type_ in py_types:
             logger.log('  # %s:' % type_)

--- a/pythonz/commands/list.py
+++ b/pythonz/commands/list.py
@@ -7,7 +7,14 @@ from pythonz.installer.pythoninstaller import CPythonInstaller, StacklessInstall
 from pythonz.log import logger
 
 
-PY_TYPES = ['cpython', 'stackless', 'pypy', 'pypy3', 'jython']
+PY_INSTALLERS = {'cpython': CPythonInstaller,
+                 'stackless': StacklessInstaller,
+                 'pypy': PyPyInstaller,
+                 'pypy3': PyPy3Installer,
+                 'jython': JythonInstaller}
+
+PY_TYPES = sorted(PY_INSTALLERS.keys())
+
 
 
 class ListCommand(Command):
@@ -56,16 +63,11 @@ class ListCommand(Command):
 
     def all(self, py_type):
         logger.log('# Available Python versions')
-        groups = zip(PY_TYPES,
-                     [CPythonInstaller, StacklessInstaller, PyPyInstaller,
-                      PyPy3Installer, JythonInstaller])
+        py_types = [ty for ty in PY_TYPES if py_type in ty] if py_type else PY_TYPES
 
-        if py_type:
-            groups = filter(lambda (impl, _): impl in py_type, groups)
-
-        for type_, installer in groups:
+        for type_ in py_types:
             logger.log('  # %s:' % type_)
-            for version in sorted(installer.supported_versions):
+            for version in sorted(PY_INSTALLERS[type_].supported_versions):
                 logger.log('     %s' % version)
 
 ListCommand()


### PR DESCRIPTION
https://github.com/saghul/pythonz/pull/102 broke compatibility with Python3 (due to the tuple unpacking in the lambda)

I fixed this by trying to make `all()` a bit simpler... the logic is a bit different now:

earlier `pythonz list -a -t pypy3` would print both pypy and pypy3 versions, while `pythonz list -a -t pypy` would only print pypy version

now it does the check the other way around, which is imho more logical (if you specified `pypy3` you don't care about `pypy2`)