### PR TITLE
bypass snvrevision and Makefile problem

### DIFF
--- a/pythonz/installer/pythoninstaller.py
+++ b/pythonz/installer/pythoninstaller.py
@@ -123,8 +123,14 @@ class CPythonInstaller(Installer):
     def __init__(self, version, options):
         super(CPythonInstaller, self).__init__(version, options)
 
-        if Version(self.pkg.version) >= '3.1':
+        version = Version(self.pkg.version)
+
+        if version >= '3.1':
             self.configure_options.append('--with-computed-gotos')
+
+        # fix for #109
+        if version < '2.7':
+            self.configure_options.append('SVNVERSION="Unversioned directory"')
 
         if sys.platform == "darwin":
             # set configure options


### PR DESCRIPTION
I'm assuming that the tool will always use a .tar.gz for installation, that means that `svnrevision` will always return "Unversioned directory", instead of patching the Makefile I just pass the SVNVERSION as a configuration flag.

Versions after 2.7 (actually a bit earlier) are fixed and have the quotes in the Makefile, so SVNVERSION and HGVERSION should be fine.

PR for issue #109 