### PR TITLE
Support compiling py26 without SSLv3

### DIFF
--- a/pythonz/installer/pythoninstaller.py
+++ b/pythonz/installer/pythoninstaller.py
@@ -243,6 +243,8 @@ class CPythonInstaller(Installer):
                 self._append_patch(patch_dir, ['patch-nosslv2-2.diff'])
             elif version < '2.6.9':
                 self._append_patch(patch_dir, ['patch-nosslv2-3.diff'])
+            else:
+                self._append_patch(patch_dir, ['patch-nosslv23.diff'])
         elif is_python27(version):
             if version < '2.7.2':
                 self._append_patch(common_patch_dir, ['patch-setup.py.diff'])

--- a/pythonz/patches/all/python26/patch-nosslv23.diff
+++ b/pythonz/patches/all/python26/patch-nosslv23.diff
@@ -1,0 +1,176 @@
+--- Doc/library/ssl.rst.orig
++++ Doc/library/ssl.rst
+@@ -176,7 +176,7 @@
+      'Wed May  9 00:00:00 2007'
+      >>>
+ 
+-.. function:: get_server_certificate (addr, ssl_version=PROTOCOL_SSLv3, ca_certs=None)
++.. function:: get_server_certificate (addr, ssl_version=PROTOCOL_SSLv23, ca_certs=None)
+ 
+    Given the address ``addr`` of an SSL-protected server, as a (*hostname*,
+    *port-number*) pair, fetches the server's certificate, and returns it as a
+@@ -218,14 +218,6 @@
+    Note that use of this setting requires a valid certificate validation file
+    also be passed as a value of the ``ca_certs`` parameter.
+ 
+-.. data:: PROTOCOL_SSLv2
+-
+-   Selects SSL version 2 as the channel encryption protocol.
+-
+-   .. warning::
+-
+-      SSL version 2 is insecure.  Its use is highly discouraged.
+-
+ .. data:: PROTOCOL_SSLv23
+ 
+    Selects SSL version 2 or 3 as the channel encryption protocol.  This is a
+@@ -233,11 +225,6 @@
+    an SSL connection, but it may cause the specific ciphers chosen for the
+    encryption to be of fairly low quality.
+ 
+-.. data:: PROTOCOL_SSLv3
+-
+-   Selects SSL version 3 as the channel encryption protocol.  For clients, this
+-   is the maximally compatible SSL variant.
+-
+ .. data:: PROTOCOL_TLSv1
+ 
+    Selects TLS version 1 as the channel encryption protocol.  This is the most
+--- Lib/ssl.py.orig
++++ Lib/ssl.py
+@@ -49,8 +49,6 @@
+ 
+ The following constants identify various SSL protocol variants:
+ 
+-PROTOCOL_SSLv2
+-PROTOCOL_SSLv3
+ PROTOCOL_SSLv23
+ PROTOCOL_TLSv1
+ """
+@@ -61,7 +59,7 @@
+ 
+ from _ssl import SSLError
+ from _ssl import CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
+-from _ssl import PROTOCOL_SSLv2, PROTOCOL_SSLv3, PROTOCOL_SSLv23, PROTOCOL_TLSv1
++from _ssl import PROTOCOL_SSLv23, PROTOCOL_TLSv1
+ from _ssl import RAND_status, RAND_egd, RAND_add
+ from _ssl import \
+      SSL_ERROR_ZERO_RETURN, \
+@@ -382,7 +380,7 @@
+     d = pem_cert_string.strip()[len(PEM_HEADER):-len(PEM_FOOTER)]
+     return base64.decodestring(d)
+ 
+-def get_server_certificate(addr, ssl_version=PROTOCOL_SSLv3, ca_certs=None):
++def get_server_certificate(addr, ssl_version=PROTOCOL_SSLv23, ca_certs=None):
+ 
+     """Retrieve the certificate from the server at the specified address,
+     and return it as a PEM-encoded string.
+@@ -406,10 +404,6 @@
+         return "TLSv1"
+     elif protocol_code == PROTOCOL_SSLv23:
+         return "SSLv23"
+-    elif protocol_code == PROTOCOL_SSLv2:
+-        return "SSLv2"
+-    elif protocol_code == PROTOCOL_SSLv3:
+-        return "SSLv3"
+     else:
+         return "<unknown>"
+ 
+--- Lib/test/test_ssl.py.orig
++++ Lib/test/test_ssl.py
+@@ -59,9 +59,7 @@
+                 raise
+ 
+     def test_constants(self):
+-        ssl.PROTOCOL_SSLv2
+         ssl.PROTOCOL_SSLv23
+-        ssl.PROTOCOL_SSLv3
+         ssl.PROTOCOL_TLSv1
+         ssl.CERT_NONE
+         ssl.CERT_OPTIONAL
+@@ -850,33 +848,12 @@
+             bad_cert_test(os.path.join(os.path.dirname(__file__) or os.curdir,
+                                        "badkey.pem"))
+ 
+-        def test_protocol_sslv2(self):
+-            """Connecting to an SSLv2 server with various client options"""
+-            if test_support.verbose:
+-                sys.stdout.write("\ntest_protocol_sslv2 disabled, "
+-                                 "as it fails on OpenSSL 1.0.0+")
+-            return
+-            try_protocol_combo(ssl.PROTOCOL_SSLv2, ssl.PROTOCOL_SSLv2, True)
+-            try_protocol_combo(ssl.PROTOCOL_SSLv2, ssl.PROTOCOL_SSLv2, True, ssl.CERT_OPTIONAL)
+-            try_protocol_combo(ssl.PROTOCOL_SSLv2, ssl.PROTOCOL_SSLv2, True, ssl.CERT_REQUIRED)
+-            try_protocol_combo(ssl.PROTOCOL_SSLv2, ssl.PROTOCOL_SSLv23, True)
+-            try_protocol_combo(ssl.PROTOCOL_SSLv2, ssl.PROTOCOL_SSLv3, False)
+-            try_protocol_combo(ssl.PROTOCOL_SSLv2, ssl.PROTOCOL_TLSv1, False)
+-
+         def test_protocol_sslv23(self):
+             """Connecting to an SSLv23 server with various client options"""
+             if test_support.verbose:
+                 sys.stdout.write("\ntest_protocol_sslv23 disabled, "
+                                  "as it fails on OpenSSL 1.0.0+")
+             return
+-            try:
+-                try_protocol_combo(ssl.PROTOCOL_SSLv23, ssl.PROTOCOL_SSLv2, True)
+-            except (ssl.SSLError, socket.error), x:
+-                # this fails on some older versions of OpenSSL (0.9.7l, for instance)
+-                if test_support.verbose:
+-                    sys.stdout.write(
+-                        " SSL2 client to SSL23 server test unexpectedly failed:\n %s\n"
+-                        % str(x))
+             try_protocol_combo(ssl.PROTOCOL_SSLv23, ssl.PROTOCOL_SSLv3, True)
+             try_protocol_combo(ssl.PROTOCOL_SSLv23, ssl.PROTOCOL_SSLv23, True)
+             try_protocol_combo(ssl.PROTOCOL_SSLv23, ssl.PROTOCOL_TLSv1, True)
+@@ -898,7 +875,6 @@
+             try_protocol_combo(ssl.PROTOCOL_SSLv3, ssl.PROTOCOL_SSLv3, True)
+             try_protocol_combo(ssl.PROTOCOL_SSLv3, ssl.PROTOCOL_SSLv3, True, ssl.CERT_OPTIONAL)
+             try_protocol_combo(ssl.PROTOCOL_SSLv3, ssl.PROTOCOL_SSLv3, True, ssl.CERT_REQUIRED)
+-            try_protocol_combo(ssl.PROTOCOL_SSLv3, ssl.PROTOCOL_SSLv2, False)
+             try_protocol_combo(ssl.PROTOCOL_SSLv3, ssl.PROTOCOL_SSLv23, False)
+             try_protocol_combo(ssl.PROTOCOL_SSLv3, ssl.PROTOCOL_TLSv1, False)
+ 
+@@ -911,8 +887,6 @@
+             try_protocol_combo(ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_TLSv1, True)
+             try_protocol_combo(ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_TLSv1, True, ssl.CERT_OPTIONAL)
+             try_protocol_combo(ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_TLSv1, True, ssl.CERT_REQUIRED)
+-            try_protocol_combo(ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_SSLv2, False)
+-            try_protocol_combo(ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_SSLv3, False)
+             try_protocol_combo(ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_SSLv23, False)
+ 
+         def test_starttls(self):
+--- Modules/_ssl.c.orig
++++ Modules/_ssl.c
+@@ -62,8 +62,6 @@
+ };
+ 
+ enum py_ssl_version {
+-    PY_SSL_VERSION_SSL2,
+-    PY_SSL_VERSION_SSL3,
+     PY_SSL_VERSION_SSL23,
+     PY_SSL_VERSION_TLS1
+ };
+@@ -300,12 +298,6 @@
+     PySSL_BEGIN_ALLOW_THREADS
+     if (proto_version == PY_SSL_VERSION_TLS1)
+         self->ctx = SSL_CTX_new(TLSv1_method()); /* Set up context */
+-    else if (proto_version == PY_SSL_VERSION_SSL3)
+-        self->ctx = SSL_CTX_new(SSLv3_method()); /* Set up context */
+-#ifndef OPENSSL_NO_SSL2
+-    else if (proto_version == PY_SSL_VERSION_SSL2)
+-        self->ctx = SSL_CTX_new(SSLv2_method()); /* Set up context */
+-#endif
+     else if (proto_version == PY_SSL_VERSION_SSL23)
+         self->ctx = SSL_CTX_new(SSLv23_method()); /* Set up context */
+     PySSL_END_ALLOW_THREADS
+@@ -1746,10 +1738,6 @@
+                             PY_SSL_CERT_REQUIRED);
+ 
+     /* protocol versions */
+-    PyModule_AddIntConstant(m, "PROTOCOL_SSLv2",
+-                            PY_SSL_VERSION_SSL2);
+-    PyModule_AddIntConstant(m, "PROTOCOL_SSLv3",
+-                            PY_SSL_VERSION_SSL3);
+     PyModule_AddIntConstant(m, "PROTOCOL_SSLv23",
+                             PY_SSL_VERSION_SSL23);
+     PyModule_AddIntConstant(m, "PROTOCOL_TLSv1",


### PR DESCRIPTION
More recent versions of libssl and distributions shipping them no
longer include the SSLv3 symbols.  This updates the existing patch to
disable SSLv2 from the _ssl module to also exclude SSLv3.  This still
seems to work correctly and pip can download packages again.
