### PR TITLE
Make .jar a valid type in is_archive_file function.

### DIFF
--- a/pythonz/util.py
+++ b/pythonz/util.py
@@ -48,7 +48,7 @@ def splitext(name):
 
 def is_archive_file(name):
     ext = splitext(name)[1].lower()
-    return ext in ('.zip', '.tar.gz', '.tar.bz2', '.tgz', '.tar')
+    return ext in ('.zip', '.tar.gz', '.tar.bz2', '.tgz', '.tar', '.jar')
 
 def is_html(content_type):
     return content_type and content_type.startswith('text/html')


### PR DESCRIPTION
This error was reported when trying to install Jython from a local file:
```
$ pythonz install -t jython --file=~/Downloads/jython-installer-2.7.1b3.jar 2.7.1b3
ERROR: invalid file specified: ~/Downloads/jython-installer-2.7.1b3.jar
```
I believe this is because `.jar` files were not valid archive types in `is_archive_file()`. I believe this will correct the error.