### PR TITLE
Fix sudo-pythonz and added CPython 3.6.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -202,11 +202,11 @@ For more information about ``virtualenv``, check out `the virtualenv documentati
 For Python >= 3.3
 ^^^^^^^^^^^^^^^^^
 
-Use ``pyvenv`` directly from Python, e.g.::
+Use ``venv`` directly from Python, e.g.::
 
-  /usr/local/pythonz/pythons/CPython-3.4.1/bin/pyvenv pyvenv
+  /usr/local/pythonz/pythons/CPython-3.4.1/bin/python3 -m venv python3.4.1
 
-For more information about ``pyvenv``, check out `the pyvenv documentation <https://docs.python.org/3/library/venv.html>`_.
+For more information about ``venv``, check out `the venv documentation <https://docs.python.org/3/library/venv.html>`_.
 
 DTrace support
 --------------

--- a/pythonz/etc/bashrc
+++ b/pythonz/etc/bashrc
@@ -1,4 +1,5 @@
 # settings
+PATH_WITHOUT_PYTHONZ=$PATH
 PATH_ROOT="$PYTHONZ_ROOT"
 if [ -z "${PATH_ROOT}" ] ; then
     PATH_ROOT="$HOME/.pythonz"


### PR DESCRIPTION
The original PATH is not saved, leading to "bash not found"

```bash
[lunarshaddow@localhost pythonz]$ echo $PATH
/usr/local/pythonz/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/lunarshaddow/.local/bin:/home/lunarshaddow/bin

[lunarshaddow@localhost pythonz]$ sudo-pythonz list -a
/usr/bin/env: bash: No such file or directory

[lunarshaddow@localhost pythonz]$ /usr/local/pythonz/bin/pythonz list -a
# Available Python versions
  # cpython:
     2.4
     2.4.1
(abridge)

[lunarshaddow@localhost pythonz]$ sudo /usr/local/pythonz/bin/pythonz list -a
# Available Python versions
  # cpython:
     2.4
     2.4.1
(abridge)
```

Besides,
add [C Python 3.6.4](https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tgz), released on 2017-12-19.
change README to invoke venv directly instead of pyvenv script, as per the official document said.