### PR TITLE
support for python 3 only

### DIFF
--- a/pythonz-install
+++ b/pythonz-install
@@ -2,7 +2,7 @@
 
 shopt -s extglob
 
-PYTHONS="`command -v python` /usr/bin/python /usr/bin/python2"
+PYTHONS="`command -v python` /usr/bin/python /usr/bin/python2 /usr/bin/python3"
 CURL=`command -v curl`
 FETCH=`command -v fetch`
 


### PR DESCRIPTION
Ubuntu comes without python 2 but /usr/bin/python doesn't exist, only /usr/bin/python3
Adding /usr/bin/python to the list see https://github.com/saghul/pythonz/issues/118