### PR TITLE
Added libjansson-dev to the debian packages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Debian family (Ubuntu...)
 
 ::
 
-  sudo apt-get install build-essential zlib1g-dev libbz2-dev libssl-dev libreadline-dev libncurses5-dev libsqlite3-dev libgdbm-dev libdb-dev libexpat-dev libpcap-dev liblzma-dev libpcre3-dev
+  sudo apt-get install build-essential zlib1g-dev libbz2-dev libssl-dev libreadline-dev libncurses5-dev libsqlite3-dev libgdbm-dev libdb-dev libexpat-dev libpcap-dev liblzma-dev libpcre3-dev libjansson-dev
 
 If you need tkinter support, add ``tk-dev``.
 


### PR DESCRIPTION
Added libjansson-dev to the suggested debian packages to be installed so the built Python
can support JSON operations.

Should be added to the other distributions also but I am only sure it works on the latest and LTS debian and ubuntu versions.