### PR TITLE
etc/bashrc: Do not add our bin to path if already present

### DIFF
--- a/pythonz/etc/bashrc
+++ b/pythonz/etc/bashrc
@@ -20,7 +20,7 @@ PYTHONZ_COMPLETION="$PATH_ETC/bash_completion.d/pythonz_completion.sh"
 # functions
 __pythonz_set_path()
 {
-    export PATH=$PATH_ROOT/bin:$PATH
+    [[ ":$PATH:" = *":$PATH_ROOT/bin:"* ]] || PATH=$PATH_ROOT/bin:$PATH
 }
 
 __pythonz_reload()


### PR DESCRIPTION
By the name, this file is clearly intended to be invoked from a user's
~/.bashrc. However, bashrc is re-invoked for subshells that inherit
a parent shell's environment and thus must be idempotent about
changing environment variables such as $PATH or directories may be
added to $PATH multiple times.

This adds $PATH_ROOT/bin to $PATH only if it's not already in $PATH to
avoid adding multiple copies.

Also, we no longer export $PATH because it's not necessary; changing
already-exported variables changes the environment. (And if it's not
exported to the environment for some bizzarre reason, we should
probably not override that decision.)