### PR TITLE
Add fallback for python3-only installation (fixes #116)

### DIFF
--- a/pythonz/installer/pythonzinstaller.py
+++ b/pythonz/installer/pythonzinstaller.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
         # create entry point file
         with open(PATH_BIN_PYTHONZ, "w") as f:
             f.write("""#!/usr/bin/env bash
-python %s/pythonz_main.py "$@"
+$(which python || which python3) %s/pythonz_main.py "$@"
 """ % PATH_SCRIPTS)
 
         # mode 0755


### PR DESCRIPTION
This will make pythonz executable script to use either `python`
or `python3` executable from PATH to run the main script,
fixing the current problem of "command not found"
on python3-only systems.