### PR TITLE
Fix version_re for python minor version using more than one number (Starting from 3.10) 

### DIFF
--- a/pythonz/installer/pythoninstaller.py
+++ b/pythonz/installer/pythoninstaller.py
@@ -117,7 +117,7 @@ class Installer(object):
 
 
 class CPythonInstaller(Installer):
-    version_re = re.compile(r'(\d\.\d\d?(\.\d+)?)(.*)')
+    version_re = re.compile(r'(\d\.\d+(\.\d+)?)(.*)') 
     supported_versions = versions['cpython']
 
     def __init__(self, version, options):


### PR DESCRIPTION
Current issue

```
Traceback (most recent call last):
  File "/home/benoit/.pythonz/scripts/pythonz/commands/install.py", line 104, in run_command
    p.install()
  File "/home/benoit/.pythonz/scripts/pythonz/installer/pythoninstaller.py", line 205, in install
    headerinfo = Downloader.read_head_info(self.download_url)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/benoit/.pythonz/scripts/pythonz/downloader.py", line 102, in read_head_info
    raise DownloadError('Failed to fetch %s' % url)
pythonz.downloader.DownloadError: Failed to fetch http://www.python.org/ftp/python/3.12/Python-3.12.tgz
```

Working now in modified version